### PR TITLE
fix: use $history[$HISTCMD] instead of $1 for last_command detection

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -26,7 +26,7 @@ _wakatime_heartbeat() {
   # We only send the first argument, which is a binary in 99% of cases.
   # It does not include any sensitive information.
   local last_command
-  last_command=$(echo "$1" | cut -d ' ' -f1)
+  last_command=$(echo "$history[$HISTCMD]" | cut -d ' ' -f1)
 
   # We only take the `root` directory name.
   # We detect `root` directories by `.git` folder.


### PR DESCRIPTION
This addresses https://github.com/sobolevn/wakatime-zsh-plugin/issues/10

Replace $1 (which was empty 100% of the time, for me) with $history[$HISTCMD], as explained here:
https://stackoverflow.com/questions/25295186/access-to-last-command-in-zsh-not-previous-command-line/25297732#25297732