### PR TITLE
Fixed Issue With The Plugin Not Finding The Wakatime Executable

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -13,7 +13,7 @@ _wakatime_heartbeat() {
 
   # Set a custom path for the wakatime-cli binary
   # otherwise point to the default `wakatime`
-  local wakatime_bin="${ZSH_WAKATIME_BIN:='wakatime'}"
+  local wakatime_bin="${ZSH_WAKATIME_BIN:=wakatime}"
 
   # Checks if `wakatime` is installed,
   if ! wakatime_loc="$(type -p "$wakatime_bin")"; then


### PR DESCRIPTION
After Following The Install Steps On The Wakatime WIKI (Installed With Antigen), The Plugin Kept Returning Error:

    wakatime cli is not installed, run:
    $ pip install wakatime
    OR:
    Option 1: Check that wakatime is in PATH
    Option 2: Set a custom path with $ export ZSH_WAKATIME_BIN=/path/to/wakatime-cli
    Time is not tracked for now.
    
I Tracked It Down To The Initialization Of The `wakatime_bin` Variable Which Was Being Set To A String Literal `'wakatime'` Instead Of `wakatime` So The Type Command Couldn't Resolve Command `'wakatime'`.
    
Although Resetting The `ZSH_WAKATIME_BIN` Environment Variable Might've Worked (It Didn't For Me), I Just Thought It'd Be Easier To Fix It Out Of The Box Which This PR Does.