### PR TITLE
Adds Check For Config File In The Event That This Plugin Is Installed First.

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -13,7 +13,7 @@ _wakatime_heartbeat() {
 
   # Set a custom path for the wakatime-cli binary
   # otherwise point to the default `wakatime`
-  local wakatime_bin="${ZSH_WAKATIME_BIN:='wakatime'}"
+  local wakatime_bin="${ZSH_WAKATIME_BIN:=wakatime}"
 
   # Checks if `wakatime` is installed,
   if ! wakatime_loc="$(type -p "$wakatime_bin")"; then

--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -2,6 +2,27 @@
 #
 # Documentation is available at:
 # https://github.com/sobolevn/wakatime-zsh-plugin
+#
+
+check_file() {
+	local wakatime_home="${WAKATIME_HOME:=$HOME}"
+	[ ! -f $wakatime_home/.wakatime.cfg ] || {
+		return
+	}
+	echo 'No Configuration File For Wakatime Found'
+	echo -n 'Please Enter Your API Key => '
+	read -r api_key
+	[ ! -z $api_key ] || {
+		echo 'Invalid API Key Provided, Exiting!'
+		exit 1
+	}
+cat << EOF > $wakatime_home/.wakatime.cfg
+[settings]
+api_key = $api_key
+EOF
+
+}
+
 
 _wakatime_heartbeat() {
   # Sends a heartbeat to the wakatime server before each command.
@@ -73,6 +94,8 @@ _wakatime_heartbeat() {
     $should_work_online \
     &>/dev/null </dev/null &!
 }
+
+check_file
 
 # See docs on `add-zsh-hook`:
 # https://github.com/zsh-users/zsh/blob/master/Functions/Misc/add-zsh-hook


### PR DESCRIPTION
This Contribution Adds The Check For A Wakatime Configuration File And If Not Found, Requests The API Key To Enable Reflection Of Coding Stats On The Wakatime Dashboard.