### PR TITLE
Update wakatime.plugin.zsh

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -13,7 +13,7 @@ _wakatime_heartbeat() {
 
   # Set a custom path for the wakatime-cli binary
   # otherwise point to the default `~/.wakatime/wakatime-cli`
-  local wakatime_bin="${ZSH_WAKATIME_BIN:=~/.wakatime/wakatime-cli}"
+  local wakatime_bin="${ZSH_WAKATIME_BIN:=$HOME/.wakatime/wakatime-cli}"
 
   # Checks if `wakatime` is installed,
   if ! wakatime_loc="$(type -p "$wakatime_bin")"; then


### PR DESCRIPTION
In ZSH, if set to `local wakatime_bin="${ZSH_WAKATIME_BIN:=~/.wakatime/wakatime-cli}"` then an error occurs:

![image](https://user-images.githubusercontent.com/4349962/165356563-6642e3ea-90e4-44f5-ab38-bb1b41b49e3b.png)

Changing this to `local wakatime_bin="${ZSH_WAKATIME_BIN:=$HOME/.wakatime/wakatime-cli}"` resolves.

This is possibly caused by how "~" is dealt with in variable expansion ([link](https://unix.stackexchange.com/questions/146671/does-always-equal-home/146697#146697)). 

It seems better in the long run to use a variable that's already inbuilt to ZSH to accomplish this ([Popular Environment Variables](https://linuxhint.com/set-environment-variable-zsh/)).

Fixes https://github.com/sobolevn/wakatime-zsh-plugin/issues/20