### PR TITLE
fix: rename plugin identifier to match Wakapi/WakaTime user-agent parser

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -60,7 +60,7 @@ _wakatime_heartbeat() {
   fi
 
   "$wakatime_bin" --write \
-    --plugin 'wakatime-zsh-plugin/0.2.2' \
+    --plugin 'zsh-wakatime/0.2.2' \
     --entity-type app \
     --entity "$last_command" \
     --project "${root_directory:t}" \


### PR DESCRIPTION
## Summary

- Renames `--plugin` value from `wakatime-zsh-plugin/0.2.2` to `zsh-wakatime/0.2.2` to fix OS and editor detection in Wakapi/WakaTime dashboards

## Problem

Wakapi's [`ParseUserAgent`](https://github.com/muety/wakapi/blob/master/utils/http.go) function uses a regex that expects the plugin name to follow the `<editor>-wakatime/<version>` convention (e.g. `vim-wakatime`, `vscode-wakatime`). The current name `wakatime-zsh-plugin` doesn't match this pattern, causing both the **OS** and **editor** fields to be empty/unknown in the dashboard.

**User-agent sent:**
```
wakatime/v1.139.1 (linux-5.10.60-qnap-unknown) go1.25.5 wakatime-zsh-plugin/0.2.2
```

**Regex (simplified):**
```
([^/\s]+)-wakatime/.+$
```

The regex captures the part _before_ `-wakatime` as the editor name. Since `wakatime-zsh-plugin` has `wakatime-` as a prefix instead of `-wakatime` as a suffix, the entire match fails — losing both the editor and OS extraction.

## Fix

Rename to `zsh-wakatime/0.2.2`, which follows the same convention as all other WakaTime editor plugins.

## Verified

Tested against a self-hosted Wakapi instance. Before and after:

| | user_agent | editor | operating_system |
|---|---|---|---|
| **Before** | `... wakatime-zsh-plugin/0.2.2` | _(empty)_ | _(empty)_ |
| **After** | `... zsh-wakatime/0.2.2` | `Zsh` | `Linux` |