### PR TITLE
Use --alternate-project instead of --project

### DIFF
--- a/wakatime.plugin.zsh
+++ b/wakatime.plugin.zsh
@@ -63,9 +63,15 @@ _wakatime_heartbeat() {
     should_work_online=''
   fi
 
+  # `--alternate-project` instead of `--project`: since wakatime-cli v2.24
+  # each invocation also parses AI agent transcripts, and a hard `--project`
+  # would be inherited by those AI heartbeats, overriding their own per-file
+  # project detection (see issue #25). An alternate project is only used
+  # when nothing else is detected, which for this plugin's own app
+  # heartbeats gives the same result as `--project` did.
   local project_option
   if [ -n "$root_directory" ]; then
-    project_option="--project ${root_directory:t}"
+    project_option="--alternate-project ${root_directory:t}"
   fi
 
   "$wakatime_bin" --write \


### PR DESCRIPTION
Closes #25.

One-word change as discussed there: `--alternate-project` is only used by wakatime-cli when its own project detection finds nothing, so the plugin's own app heartbeats keep exactly the same project as before (`Terminal` or the repo name), while the AI heartbeats that wakatime-cli v2.24+ parses on the same invocation stop being overridden and resolve to their real per-file projects. Added a short comment so the reasoning survives future refactors.

Tested locally (the equivalent change on 0.2.2): AI heartbeats immediately started resolving to correct projects; the plugin's own heartbeats unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)